### PR TITLE
No more item traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1029,6 +1029,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2354,6 +2363,8 @@ dependencies = [
  "num",
  "oorandom",
  "rand 0.8.3",
+ "strum",
+ "strum_macros",
  "uuid",
 ]
 
@@ -2425,6 +2436,24 @@ name = "strsim"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
+
+[[package]]
+name = "strum"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaf86bbcfd1fa9670b7a129f64fc0c9fcbbfe4f1bc4210e9e98fe71ffc12cde2"
+
+[[package]]
+name = "strum_macros"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d06aaeeee809dbc59eb4556183dd927df67db1540de5be8d3ec0b6636358a5ec"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "syn"
@@ -2543,6 +2572,12 @@ checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
 dependencies = [
  "version_check",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ rand = "0.8.3"
 num = "0.3.1"
 mint = "0.5.6"
 uuid = { version = "0.8", features = ["serde", "v4"] }
+strum = "0.21"
+strum_macros = "0.21"
 
 # https://github.com/ggez/ggez/blob/master/docs/FAQ.md#imagesound-loading-and-font-rendering-is-slow
 [profile.dev]

--- a/src/inhabitant.rs
+++ b/src/inhabitant.rs
@@ -146,7 +146,7 @@ impl Inhabitant {
                 }
             }
             Some(Behavior::Eat) => {
-                if self.has_item(vec![ItemType::Food(FoodType::EnergyBar)]) {
+                if self.has_item(get_food_types()) {
                     // If we have food on our person, eat it
                     println!("{} Eating from inventory", self);
                     self.eat(&Item::new(
@@ -154,7 +154,7 @@ impl Inhabitant {
                         ItemType::Food(FoodType::EnergyBar),
                     )); // TODO: Actually consume the food from inventory
                     self.behaviors.pop();
-                } else if current_tile.has_item(vec![ItemType::Food(FoodType::EnergyBar)]) {
+                } else if current_tile.has_item(get_food_types()) {
                     // If there's food here on this tile, eat it
                     println!("{} Eating from tile", self);
                     self.eat(&Item::new(
@@ -165,15 +165,11 @@ impl Inhabitant {
                 } else {
                     // Otherwise, search for it
                     println!("{} Searching for food", self);
-                    self.behaviors
-                        .push(Behavior::Search(vec![ItemType::Food(FoodType::EnergyBar)]));
+                    self.behaviors.push(Behavior::Search(get_food_types()));
                 }
             }
             Some(Behavior::Drink) => {
-                if self.has_item(vec![
-                    ItemType::Drink(DrinkType::Water),
-                    ItemType::Drink(DrinkType::Coffee),
-                ]) {
+                if self.has_item(get_drink_types()) {
                     // If we have drink on our person, drink it
                     println!("{} Drinking from inventory", self);
                     self.drink(&Item::new(
@@ -181,10 +177,7 @@ impl Inhabitant {
                         ItemType::Drink(DrinkType::Water),
                     )); // TODO: Actually consume the drink from inventory
                     self.behaviors.pop();
-                } else if current_tile.has_item(vec![
-                    ItemType::Drink(DrinkType::Water),
-                    ItemType::Drink(DrinkType::Coffee),
-                ]) {
+                } else if current_tile.has_item(get_drink_types()) {
                     // If there's drink here on this tile, drink it
                     println!("{} Drinking from tile", self);
                     self.drink(&Item::new(
@@ -195,10 +188,7 @@ impl Inhabitant {
                 } else {
                     // Otherwise, search for it
                     println!("{} Searching for drink", self);
-                    self.behaviors.push(Behavior::Search(vec![
-                        ItemType::Drink(DrinkType::Water),
-                        ItemType::Drink(DrinkType::Coffee),
-                    ]));
+                    self.behaviors.push(Behavior::Search(get_drink_types()));
                 }
             }
             Some(Behavior::Search(item_types)) => match self.dest {

--- a/src/inhabitant.rs
+++ b/src/inhabitant.rs
@@ -41,7 +41,7 @@ pub struct Inhabitant {
     thirst: u8,
     age: time::Duration,
 
-    items: Vec<Box<dyn Item>>,
+    items: Vec<Item>,
 
     id: uuid::Uuid,
 }
@@ -149,12 +149,18 @@ impl Inhabitant {
                 if self.has_item(ItemType::Food) {
                     // If we have food on our person, eat it
                     println!("{} Eating from inventory", self);
-                    self.eat(&Food::new(current_tile.pos)); // TODO: Actually consume the food from inventory
+                    self.eat(&Item::new(
+                        current_tile.pos,
+                        ItemType::Food(FoodType::EnergyBar),
+                    )); // TODO: Actually consume the food from inventory
                     self.behaviors.pop();
                 } else if current_tile.has_item(ItemType::Food) {
                     // If there's food here on this tile, eat it
                     println!("{} Eating from tile", self);
-                    self.eat(&Food::new(current_tile.pos)); // TODO: Actually consume the food from the tile
+                    self.eat(&Item::new(
+                        current_tile.pos,
+                        ItemType::Food(FoodType::EnergyBar),
+                    )); // TODO: Actually consume the food from the tile
                     self.behaviors.pop();
                 } else {
                     // Otherwise, search for it
@@ -166,12 +172,18 @@ impl Inhabitant {
                 if self.has_item(ItemType::Drink) {
                     // If we have drink on our person, drink it
                     println!("{} Drinking from inventory", self);
-                    self.drink(&Drink::new(current_tile.pos)); // TODO: Actually consume the drink from inventory
+                    self.drink(&Item::new(
+                        current_tile.pos,
+                        ItemType::Drink(DrinkType::Water),
+                    )); // TODO: Actually consume the drink from inventory
                     self.behaviors.pop();
                 } else if current_tile.has_item(ItemType::Drink) {
                     // If there's drink here on this tile, drink it
                     println!("{} Drinking from tile", self);
-                    self.drink(&Drink::new(current_tile.pos)); // TODO: Actually consume the drink from the tile
+                    self.drink(&Item::new(
+                        current_tile.pos,
+                        ItemType::Drink(DrinkType::Water),
+                    )); // TODO: Actually consume the drink from the tile
                     self.behaviors.pop();
                 } else {
                     // Otherwise, search for it
@@ -343,12 +355,14 @@ impl Inhabitant {
         }
     }
 
-    pub fn eat(&mut self, item: &Food) {
-        self.hunger = self.hunger.saturating_sub(item.energy);
+    pub fn eat(&mut self, item: &Item) {
+        // TODO: Test actually edible?
+        self.hunger = self.hunger.saturating_sub(item.get_energy());
     }
 
-    pub fn drink(&mut self, item: &Drink) {
-        self.thirst = self.thirst.saturating_sub(item.hydration);
+    pub fn drink(&mut self, item: &Item) {
+        // TODO: Test actually drinkable?
+        self.thirst = self.thirst.saturating_sub(item.get_hydration());
     }
 
     pub fn take_damage(&mut self, amount: u8) {

--- a/src/item.rs
+++ b/src/item.rs
@@ -3,6 +3,9 @@ use ggez::{graphics, Context, GameError, GameResult};
 
 use uuid::Uuid;
 
+use strum::IntoEnumIterator;
+use strum_macros::EnumIter;
+
 use core::fmt;
 
 // Alias some types to making reading/writing code easier and also in case math libraries change again
@@ -15,21 +18,46 @@ pub enum ItemType {
     Container(ContainerType),
 }
 
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug, EnumIter)]
 pub enum FoodType {
     EnergyBar,
 }
 
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug, EnumIter)]
 pub enum DrinkType {
     Water,
     Coffee,
 }
 
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug, EnumIter)]
 pub enum ContainerType {
     Fridge,
     Locker,
+}
+
+// Helper functions to return all possible subtypes of a given item type
+pub fn get_food_types() -> Vec<ItemType> {
+    let mut types = vec![];
+    for kind in FoodType::iter() {
+        types.push(ItemType::Food(kind));
+    }
+    types
+}
+
+pub fn get_drink_types() -> Vec<ItemType> {
+    let mut types = vec![];
+    for kind in DrinkType::iter() {
+        types.push(ItemType::Drink(kind));
+    }
+    types
+}
+
+pub fn get_container_types() -> Vec<ItemType> {
+    let mut types = vec![];
+    for kind in ContainerType::iter() {
+        types.push(ItemType::Container(kind));
+    }
+    types
 }
 
 // An item is the base of objects that live inside the station on tiles and inhabitants can interact

--- a/src/item.rs
+++ b/src/item.rs
@@ -10,124 +10,78 @@ type Point2 = glam::Vec2;
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub enum ItemType {
-    Food,
-    Drink,
-    Container,
+    Food(FoodType),
+    Drink(DrinkType),
+    Container(ContainerType),
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub enum FoodType {
+    EnergyBar,
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub enum DrinkType {
+    Water,
+    Coffee,
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub enum ContainerType {
+    Fridge,
+    Locker,
 }
 
 // An item is the base of objects that live inside the station on tiles and inhabitants can interact
-pub trait Item {
-    fn get_id(&self) -> Uuid;
-    fn get_name(&self) -> String;
-    fn draw(&self, ctx: &mut Context, pos: Point2, camera: &crate::Camera) -> GameResult<()>;
-    fn update(&mut self, ctx: &mut Context) -> GameResult<()>;
-    fn get_type(&self) -> ItemType;
-    fn get_items(&self) -> &Vec<Box<dyn Item>>;
-}
-
-impl fmt::Debug for dyn Item {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{} ({:?})] {}",
-            self.get_id(),
-            self.get_type(),
-            self.get_name()
-        )
-    }
-}
-
-#[derive(Debug)]
-pub struct Food {
-    pub energy: u8,
-    pos: super::GridPosition,
+pub struct Item {
     id: uuid::Uuid,
-    items: Vec<Box<dyn Item>>,
+    kind: ItemType,
+    pub pos: super::GridPosition,
+    items: Vec<Item>,
+    capacity: usize,
 }
 
-impl Item for Food {
-    fn get_id(&self) -> Uuid {
-        self.id
-    }
-
-    fn get_type(&self) -> ItemType {
-        ItemType::Food
-    }
-
-    fn get_name(&self) -> String {
-        format!("Yummy yummy food. Restores {} hunger", self.energy)
-    }
-
-    fn draw(
-        &self,
-        ctx: &mut Context,
-        station_pos: Point2,
-        camera: &crate::Camera,
-    ) -> GameResult<()> {
-        let pos = Point2::new(
-            (crate::TILE_WIDTH * self.pos.x as f32) - (crate::TILE_WIDTH / 2.0),
-            (crate::TILE_WIDTH * self.pos.y as f32) - (crate::TILE_WIDTH / 2.0),
-        );
-        let mesh = Mesh::new_circle(
-            ctx,
-            DrawMode::fill(),
-            pos,
-            crate::TILE_WIDTH / 2.0 - 10.0,
-            0.1,
-            Color::new(1.0, 1.0, 0.0, 1.0),
-        )?;
-        graphics::draw(
-            ctx,
-            &mesh,
-            DrawParam::default()
-                .dest(station_pos)
-                .offset(camera.pos)
-                .scale(camera.zoom),
-        )
-    }
-
-    fn update(&mut self, _ctx: &mut Context) -> GameResult<()> {
-        Ok(())
-    }
-
-    fn get_items(&self) -> &Vec<Box<dyn Item>> {
-        &self.items
+impl fmt::Debug for Item {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "[{} ({:?})] {}", self.id, self.kind, self.get_name())
     }
 }
 
-impl Food {
-    pub fn new(pos: super::GridPosition) -> Food {
-        Food {
+impl Item {
+    pub fn new(pos: super::GridPosition, kind: ItemType) -> Item {
+        let capacity = match kind {
+            ItemType::Container(_) => 10,
+            _ => 0,
+        };
+
+        Item {
             id: Uuid::new_v4(),
+            kind: kind,
             pos,
-            energy: 10,
-            items: Vec::new(),
+            items: Vec::with_capacity(capacity),
+            capacity,
         }
     }
-}
 
-#[derive(Debug)]
-pub struct Fridge {
-    items: Vec<Box<dyn Item>>,
-    capacity: usize,
-    pos: super::GridPosition,
-    id: uuid::Uuid,
-}
-
-impl Item for Fridge {
-    fn get_id(&self) -> Uuid {
+    pub fn get_id(&self) -> Uuid {
         self.id
     }
 
-    fn get_type(&self) -> ItemType {
-        ItemType::Container
+    pub fn get_name(&self) -> String {
+        match self.kind {
+            ItemType::Food(food_type) => {
+                format!("Yummy yummy food. Restores {} hunger", 10)
+            }
+            ItemType::Drink(drink_type) => {
+                format!("A thirst-quenching beverage. Restores {} thirst", 10)
+            }
+            ItemType::Container(container_type) => {
+                format!("Storage container. Has {} items.", self.items.len())
+            }
+        }
     }
 
-    fn get_name(&self) -> String {
-        format!("Food storage. Has {} items.", self.items.len())
-    }
-
-    fn draw(
+    pub fn draw(
         &self,
         ctx: &mut Context,
         station_pos: Point2,
@@ -137,12 +91,30 @@ impl Item for Fridge {
             (crate::TILE_WIDTH * self.pos.x as f32) - (crate::TILE_WIDTH / 2.0),
             (crate::TILE_WIDTH * self.pos.y as f32) - (crate::TILE_WIDTH / 2.0),
         );
-        let mesh = Mesh::new_rectangle(
-            ctx,
-            DrawMode::fill(),
-            graphics::Rect::new(pos.x + 10.0, pos.y + 10.0, 10.0, 10.0),
-            Color::new(0.5, 0.5, 0.5, 1.0),
-        )?;
+        let mesh = match self.kind {
+            ItemType::Food(_) => Mesh::new_circle(
+                ctx,
+                DrawMode::fill(),
+                pos,
+                crate::TILE_WIDTH / 2.0 - 10.0,
+                0.1,
+                Color::new(1.0, 1.0, 0.0, 1.0),
+            )?,
+            ItemType::Drink(_) => Mesh::new_circle(
+                ctx,
+                DrawMode::fill(),
+                pos,
+                crate::TILE_WIDTH / 2.0 - 10.0,
+                0.1,
+                Color::new(1.0, 1.0, 0.0, 1.0),
+            )?,
+            ItemType::Container(_) => Mesh::new_rectangle(
+                ctx,
+                DrawMode::fill(),
+                graphics::Rect::new(pos.x + 10.0, pos.y + 10.0, 10.0, 10.0),
+                Color::new(0.5, 0.5, 0.5, 1.0),
+            )?,
+        };
         graphics::draw(
             ctx,
             &mesh,
@@ -153,7 +125,7 @@ impl Item for Fridge {
         )
     }
 
-    fn update(&mut self, ctx: &mut Context) -> GameResult<()> {
+    pub fn update(&mut self, ctx: &mut Context) -> GameResult<()> {
         // Update all the contents
         for item in self.items.iter_mut() {
             item.update(ctx)?;
@@ -162,152 +134,103 @@ impl Item for Fridge {
         Ok(())
     }
 
-    fn get_items(&self) -> &Vec<Box<dyn Item>> {
+    pub fn get_type(&self) -> ItemType {
+        self.kind
+    }
+
+    pub fn get_items(&self) -> &Vec<Item> {
         &self.items
     }
-}
-
-impl Fridge {
-    pub fn new(pos: super::GridPosition) -> Fridge {
-        let mut fridge = Fridge {
-            id: Uuid::new_v4(),
-            pos,
-            capacity: 10,
-            items: Vec::with_capacity(10),
-        };
-
-        fridge.add_item(Food::new(pos)).unwrap();
-
-        fridge
-    }
-
-    pub fn add_item(&mut self, item: Food) -> GameResult<()> {
+    pub fn add_item(&mut self, item: Item) -> GameResult<()> {
         if self.items.len() >= self.capacity {
-            return Err(GameError::CustomError("Fridge is at capacity".to_string()));
+            return Err(GameError::CustomError(
+                "Container is at capacity".to_string(),
+            ));
         }
 
-        self.items.push(Box::new(item));
+        self.items.push(item);
 
         Ok(())
     }
-
     // Given an item uuid, removes it from the fridge
     pub fn remove_item(&mut self, id: uuid::Uuid) {
-        self.items.retain(|item| item.get_id() == id)
-    }
-}
-
-#[derive(Debug)]
-pub struct Drink {
-    pub hydration: u8,
-    pos: super::GridPosition,
-    id: uuid::Uuid,
-    items: Vec<Box<dyn Item>>,
-}
-
-impl Item for Drink {
-    fn get_id(&self) -> Uuid {
-        self.id
+        self.items.retain(|item| item.id == id)
     }
 
-    fn get_type(&self) -> ItemType {
-        ItemType::Drink
+    pub fn get_energy(&self) -> u8 {
+        match self.kind {
+            ItemType::Food(food_type) => match food_type {
+                FoodType::EnergyBar => 10,
+            },
+            _ => 0,
+        }
     }
 
-    fn get_name(&self) -> String {
-        format!(
-            "A thirst-quenching beverage. Restores {} thirst",
-            self.hydration
-        )
-    }
-
-    fn draw(
-        &self,
-        ctx: &mut Context,
-        station_pos: Point2,
-        camera: &crate::Camera,
-    ) -> GameResult<()> {
-        let pos = Point2::new(
-            (crate::TILE_WIDTH * self.pos.x as f32) - (crate::TILE_WIDTH / 2.0),
-            (crate::TILE_WIDTH * self.pos.y as f32) - (crate::TILE_WIDTH / 2.0),
-        );
-        let mesh = Mesh::new_circle(
-            ctx,
-            DrawMode::fill(),
-            pos,
-            crate::TILE_WIDTH / 2.0 - 10.0,
-            0.1,
-            Color::new(1.0, 1.0, 0.0, 1.0),
-        )?;
-        graphics::draw(
-            ctx,
-            &mesh,
-            DrawParam::default()
-                .dest(station_pos)
-                .offset(camera.pos)
-                .scale(camera.zoom),
-        )
-    }
-
-    fn update(&mut self, _ctx: &mut Context) -> GameResult<()> {
-        Ok(())
-    }
-
-    fn get_items(&self) -> &Vec<Box<dyn Item>> {
-        &self.items
-    }
-}
-
-impl Drink {
-    pub fn new(pos: super::GridPosition) -> Drink {
-        Drink {
-            id: Uuid::new_v4(),
-            pos,
-            hydration: 10,
-            items: Vec::new(),
+    pub fn get_hydration(&self) -> u8 {
+        match self.kind {
+            ItemType::Drink(drink_type) => match drink_type {
+                DrinkType::Water => 10,
+                DrinkType::Coffee => 8,
+            },
+            _ => 0,
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{Food, Fridge};
-    use crate::item::Item;
+    use super::{ContainerType, FoodType, Item, ItemType};
     use crate::station::GridPosition;
 
     #[test]
     fn new_fridge_contains_items() {
-        let fridge = Fridge::new(GridPosition::new(1, 1));
+        let fridge = Item::new(
+            GridPosition::new(1, 1),
+            ItemType::Container(ContainerType::Fridge),
+        );
         assert_eq!(1, fridge.items.len());
     }
 
     #[test]
     fn fridge_add_item() {
-        let mut fridge = Fridge::new(GridPosition::new(1, 1));
-        assert!(fridge.add_item(Food::new(fridge.pos)).is_ok());
-        assert_eq!(2, fridge.items.len());
+        let fridge = Item::new(
+            GridPosition::new(1, 1),
+            ItemType::Container(ContainerType::Fridge),
+        );
+        assert!(fridge
+            .add_item(Item::new(fridge.pos, ItemType::Food(FoodType::EnergyBar)))
+            .is_ok());
+        assert_eq!(1, fridge.items.len());
     }
 
     #[test]
     fn fridge_max_items() {
-        let mut fridge = Fridge::new(GridPosition::new(1, 1));
+        let fridge = Item::new(
+            GridPosition::new(1, 1),
+            ItemType::Container(ContainerType::Fridge),
+        );
         while fridge.items.len() < fridge.capacity {
-            assert!(fridge.add_item(Food::new(fridge.pos)).is_ok());
+            assert!(fridge
+                .add_item(Item::new(fridge.pos, ItemType::Food(FoodType::EnergyBar)))
+                .is_ok());
         }
 
-        let result = fridge.add_item(Food::new(fridge.pos));
+        let result = fridge.add_item(Item::new(fridge.pos, ItemType::Food(FoodType::EnergyBar)));
         assert!(result.is_err());
     }
 
     #[test]
     fn fridge_remove_item() {
-        let mut fridge = Fridge::new(GridPosition::new(1, 1));
-        let food = Food::new(fridge.pos);
+        let fridge = Item::new(
+            GridPosition::new(1, 1),
+            ItemType::Container(ContainerType::Fridge),
+        );
+        let food = Item::new(fridge.pos, ItemType::Food(FoodType::EnergyBar));
         let id = food.get_id();
         assert!(fridge.add_item(food).is_ok());
-        assert_eq!(2, fridge.items.len());
+        assert_eq!(1, fridge.items.len());
 
         fridge.remove_item(id);
-        assert_eq!(1, fridge.items.len());
+        assert_eq!(0, fridge.items.len());
     }
 }

--- a/src/station.rs
+++ b/src/station.rs
@@ -87,9 +87,9 @@ impl PartialOrd for Movement {
 // A Tile object, which the Station is made of
 #[derive(Debug)]
 pub struct Tile {
-    pub pos: GridPosition,         // x,y position of the tile within the station
-    pub kind: TileType,            // what type of square the tile is
-    pub items: Vec<Box<dyn Item>>, // Items that are present on/in the tile
+    pub pos: GridPosition, // x,y position of the tile within the station
+    pub kind: TileType,    // what type of square the tile is
+    pub items: Vec<Item>,  // Items that are present on/in the tile
 }
 
 // Tiles are equal if they are in the same spot
@@ -146,8 +146,8 @@ impl Tile {
     }
 
     // Add an item to the tile
-    pub fn add_item<T: Item + 'static>(&mut self, item: T) {
-        self.items.push(Box::new(item));
+    pub fn add_item(&mut self, item: Item) {
+        self.items.push(item);
     }
 
     // Do we have an item of this type on us?
@@ -159,18 +159,20 @@ impl Tile {
         false
     }
 
-    pub fn get_item(&self, item_type: ItemType) -> Option<&Box<dyn Item>> {
+    pub fn get_item(&self, item_type: ItemType) -> Option<&Item> {
         for item in self.items.iter() {
             if item.get_type() == item_type {
                 return Some(item);
             }
 
             // If this is a container, we need to iterate inside
-            if item.get_type() == ItemType::Container {
-                for subitem in item.get_items().iter() {
-                    // Is this what we're looking for?
-                    if subitem.get_type() == item_type {
-                        return Some(item);
+            match item.get_type() {
+                ItemType::Container(_) => {
+                    for subitem in item.get_items().iter() {
+                        // Is this what we're looking for?
+                        if subitem.get_type() == item_type {
+                            return Some(item);
+                        }
                     }
                 }
             }
@@ -288,7 +290,10 @@ impl Station {
         for (_pos, tile) in self.tiles.iter_mut() {
             if tile.kind == TileType::Floor {
                 println!("Placing fridge at {:#?}", tile);
-                tile.add_item(Fridge::new(tile.pos));
+                tile.add_item(Item::new(
+                    tile.pos,
+                    ItemType::Container(ContainerType::Fridge),
+                ));
                 break;
             }
         }
@@ -526,11 +531,13 @@ impl Station {
                 }
 
                 // If this is a container, we need to iterate inside
-                if item.get_type() == ItemType::Container {
-                    for subitem in item.get_items().iter() {
-                        // Is this what we're looking for?
-                        if subitem.get_type() == kind {
-                            found.push(pos);
+                match item.get_type() {
+                    ItemType::Container(_) => {
+                        for subitem in item.get_items().iter() {
+                            // Is this what we're looking for?
+                            if subitem.get_type() == kind {
+                                found.push(pos);
+                            }
                         }
                     }
                 }
@@ -921,7 +928,7 @@ impl Station {
 #[cfg(test)]
 mod tests {
     use super::{GridPosition, Point2, Station, Tile, TileType, WallDirection};
-    use crate::item::{Food, Fridge, ItemType};
+    use crate::item::{ContainerType, FoodType, Item, ItemType};
     use oorandom::Rand32;
     use std::collections::HashMap;
 
@@ -1173,19 +1180,19 @@ mod tests {
         let mut s = test_station_full();
         let pos = GridPosition::new(1, 1);
         let tile = s.get_tile_mut(pos).unwrap();
-        tile.add_item(Food::new(pos));
+        tile.add_item(Item::new(pos, ItemType::Food(FoodType::EnergyBar)));
 
-        let found = s.find_item(ItemType::Food);
+        let found = s.find_item(ItemType::Food(FoodType::EnergyBar));
         assert_eq!(1, found.len(), "found one food type");
 
         let pos = GridPosition::new(1, 2);
         let tile = s.get_tile_mut(pos).unwrap();
-        let fridge = Fridge::new(pos);
+        let fridge = Item::new(pos, ItemType::Container(ContainerType::Fridge));
         tile.add_item(fridge);
 
-        let found = s.find_item(ItemType::Container);
+        let found = s.find_item(ItemType::Container(ContainerType::Fridge));
         assert_eq!(1, found.len(), "found one container type");
-        let found = s.find_item(ItemType::Food);
+        let found = s.find_item(ItemType::Food(FoodType::EnergyBar));
         println!("{:?}", found);
         assert_eq!(
             2,

--- a/src/station.rs
+++ b/src/station.rs
@@ -151,17 +151,17 @@ impl Tile {
     }
 
     // Do we have an item of this type on us?
-    pub fn has_item(&self, item_type: ItemType) -> bool {
-        if let Some(_) = self.get_item(item_type) {
+    pub fn has_item(&self, item_types: Vec<ItemType>) -> bool {
+        if let Some(_) = self.get_item(item_types) {
             return true;
         }
 
         false
     }
 
-    pub fn get_item(&self, item_type: ItemType) -> Option<&Item> {
+    pub fn get_item(&self, item_types: Vec<ItemType>) -> Option<&Item> {
         for item in self.items.iter() {
-            if item.get_type() == item_type {
+            if item_types.contains(&item.get_type()) {
                 return Some(item);
             }
 
@@ -170,11 +170,12 @@ impl Tile {
                 ItemType::Container(_) => {
                     for subitem in item.get_items().iter() {
                         // Is this what we're looking for?
-                        if subitem.get_type() == item_type {
+                        if item_types.contains(&subitem.get_type()) {
                             return Some(item);
                         }
                     }
                 }
+                _ => (),
             }
         }
 
@@ -183,7 +184,7 @@ impl Tile {
 
     // Given an item uuid, removes it from the tile
     pub fn remove_item(&mut self, id: uuid::Uuid) {
-        self.items.retain(|item| item.get_id() == id)
+        self.items.retain(|item| item.get_id() != id)
     }
 
     // Convert a tile's grid position to a "world" position, based on where the station is
@@ -519,14 +520,14 @@ impl Station {
         path
     }
 
-    // Returns grid positions of tiles containing the desired item
+    // Returns grid positions of tiles containing the desired items
     // TODO: Take a starting position and return items closest first
-    pub fn find_item(&self, kind: ItemType) -> Vec<&GridPosition> {
+    pub fn find_items(&self, kinds: Vec<ItemType>) -> Vec<&GridPosition> {
         let mut found = Vec::new();
         for (pos, tile) in self.tiles.iter() {
             for item in tile.items.iter() {
                 // Is this what we're looking for?
-                if item.get_type() == kind {
+                if kinds.contains(&item.get_type()) {
                     found.push(pos);
                 }
 
@@ -535,11 +536,12 @@ impl Station {
                     ItemType::Container(_) => {
                         for subitem in item.get_items().iter() {
                             // Is this what we're looking for?
-                            if subitem.get_type() == kind {
+                            if kinds.contains(&subitem.get_type()) {
                                 found.push(pos);
                             }
                         }
                     }
+                    _ => (),
                 }
             }
         }
@@ -1176,13 +1178,13 @@ mod tests {
     }
 
     #[test]
-    fn find_item() {
+    fn find_items() {
         let mut s = test_station_full();
         let pos = GridPosition::new(1, 1);
         let tile = s.get_tile_mut(pos).unwrap();
         tile.add_item(Item::new(pos, ItemType::Food(FoodType::EnergyBar)));
 
-        let found = s.find_item(ItemType::Food(FoodType::EnergyBar));
+        let found = s.find_items(vec![ItemType::Food(FoodType::EnergyBar)]);
         assert_eq!(1, found.len(), "found one food type");
 
         let pos = GridPosition::new(1, 2);
@@ -1190,9 +1192,9 @@ mod tests {
         let fridge = Item::new(pos, ItemType::Container(ContainerType::Fridge));
         tile.add_item(fridge);
 
-        let found = s.find_item(ItemType::Container(ContainerType::Fridge));
+        let found = s.find_items(vec![ItemType::Container(ContainerType::Fridge)]);
         assert_eq!(1, found.len(), "found one container type");
-        let found = s.find_item(ItemType::Food(FoodType::EnergyBar));
+        let found = s.find_items(vec![ItemType::Food(FoodType::EnergyBar)]);
         println!("{:?}", found);
         assert_eq!(
             2,


### PR DESCRIPTION
Turns out Traits are very inflexible. So we're going "back" to enums for all item types. No more Box-ing, no more duplicate code between subitems. Tradeoff is losing being able to say "We only want a Fridge here". Best you can say now is "Just a Container". But the generic item case is much more common, and this supports that, with some extra functions needing to be built that say "Give me all the types of Food".